### PR TITLE
feat: add integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,75 @@
+name: integration-test
+
+on: 
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      # The ADO project to use during the test 
+      ADO_PROJECT: hol
+      # The name of the pipeline that will be created during the test
+      # a random number will be appended to this name
+      PIPELINE_NAME: integration-pipeline
+      # The repository in the ADO project that contains the
+      # azure-pipelines.yml file
+      PIPELINE_REPO: pipeline-test
+      # The image to use when creating the agent
+      JOB_IMAGE: ghcr.io/akanieski/ado-pipelines-linux:0.0.1-preview
+      # The agent pool to use during the test
+      AGENT_POOLS: test-agent-pool
+      # The k8s namespace to create all the resources in
+      NAMESPACE: ado
+      # The amount of time to wait before assuming the test has failed
+      TEST_TIMEOUT: 600s
+    # This environment should contain all the secrets
+    environment: integration
+    steps:
+      # Checkout the repo
+      - 
+        uses: actions/checkout@v2
+      # Provision a Kind cluster to run the pipeline agent on
+      - 
+        name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.3.0
+        with:
+          config: ./integration-tests/kind-config.yaml
+      # Run a script to install a local docker registry on the cluster
+      # complete with an ingress
+      -
+        name: Setup Registry
+        run: ./integration-tests/setup-registry.sh
+      # Setup QEMU and Docker for the build
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          # This allows the docker push to access the host network
+          # where the Kind cluster's registry resides
+          driver-opts: network=host
+      # Calculate what the image name should be
+      - 
+        name: Build Image Name
+        run: | 
+          GIT_SHA=$(git rev-parse --short HEAD)
+          echo "IMAGE_NAME=localhost/azure-pipelines-orchestrator:${GIT_SHA}" >> $GITHUB_ENV
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ env.IMAGE_NAME }}
+      # Invoke the actual integration test script
+      -
+        name: Run Integration Test
+        run: |
+          ./integration-tests/test-deployment.sh ${{ env.IMAGE_NAME }} \
+            ${{ secrets.ORG_URL }} \
+            ${{ secrets.ORG_PAT }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/TestResults
 .vs/
 .tmp/
+.DS_Store

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -1,0 +1,24 @@
+# Integration Tests
+
+The integration tests are designed to test the `azure-pipelines-orchestrator` on an actual Kubernetes cluster against a live Azure DevOps repo. During the test, a [kind cluster](https://kind.sigs.k8s.io/) is provisioned using the `kind-config.yaml` file that has both a local docker registry, and an `nginx` Ingress. The orchestrator is deployed, and a temporary pipeline is created for the life of tht test. Then, a pipeline job is queued to run and the script will monitor to see if the orchestrator correctly spawns a corresponding `Job` object in K8s.
+
+## Test Parameters
+
+Within the `.github/workflows/integration-tests.yaml` file the following environment variables are set:
+
+- `ADO_PROJECT`   - The Azure DevOps project where the test pipeline will run
+- `PIPELINE_NAME` - The name of the pipeline to create (a random number will be appended to this name)
+- `PIPELINE_REPO` - The name of the repo in the ADO project that contains a test `azure-pipelines.yml` file
+- `JOB_IMAGE`     - The agent image to run
+- `AGENT_POOLS`   - The agent pool(s) to use
+- `NAMESPACE`     - The k8s namespace to create all the resources in
+- `TEST_TIMEOUT`  - The amount of time to wait before assuming the test has failed
+
+## Secrets
+
+This integration test scripts require several secrets to exist in an environment called `integration`:
+
+- `ORG_URL`
+    - The ADO organization URL to use for the test
+- `ORG_PAT`
+    - The Personal Access Token for the ADO Organization. Requires the same permissions as for when provisoning an agent. Additionally, this pat should have permission to manage Service Connections and read Source Code.

--- a/integration-tests/kind-config.yaml
+++ b/integration-tests/kind-config.yaml
@@ -1,0 +1,17 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP

--- a/integration-tests/setup-registry.sh
+++ b/integration-tests/setup-registry.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+NAMESPACE=default
+
+# Create the ingress namespace
+kubectl create namespace ingress-nginx
+
+# Deploy Ngnix
+kubectl apply -n ingress-nginx -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+
+# Wait for it to be ready
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
+
+# Deploy the registry onto kubernetes
+kubectl apply -n ${NAMESPACE} -f - << EOF
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: registry-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+spec:
+  rules:
+  - http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: registry
+            port:
+              number: 5000
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: registry
+spec:
+  selector:
+    app: registry
+  ports:
+  - port: 5000
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry-deployment
+  labels:
+    app: registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      containers:
+      - name: registry
+        image: registry:2
+EOF
+
+# Wait for the registry to be ready
+kubectl wait deployment/registry-deployment -n ${NAMESPACE} --for condition=Available --timeout=60s
+
+# Wait for the registry to be fully up
+for i in {1..10}
+do
+  echo "Checking registry status..."
+  STATUS=$(curl -s -o /dev/null -w "%{http_code}" localhost/v2/)
+
+  if [ "${STATUS}" -le 399 ]; then
+    echo "Registry ready with ${STATUS}!"
+    break
+  fi
+
+  echo "Registry returned ${STATUS}. Trying again in 5 seconds"
+
+  sleep 5s
+
+done

--- a/integration-tests/test-deployment.sh
+++ b/integration-tests/test-deployment.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+
+####
+# This script will test actually spinning up the azure-pipelines-orchestrator
+# onto a k8s cluster. Afterwards, it will create a pipeline that exists just
+# for the test to ensure the orchestrator provisions the agent
+#
+# Assumes the following environment variables are set:
+#
+#   ADO_PROJECT   - The Azure DevOps project where the test pipeline will run
+#   PIPELINE_NAME - The name of the pipeline to trigger (a random number will be appended to this name)
+#   PIPELINE_REPO - The name of the repo in the ADO project that contains a test azure-pipelines.yml
+#   JOB_IMAGE     - The agent image to run
+#   AGENT_POOLS   - The agent pool(s) to use
+#   NAMESPACE     - The k8s namespace to create all the resources in
+#   TEST_TIMEOUT  - The amount of time to wait before assuming the test has failed
+####
+
+# Exit 1 on ANY error
+set -o pipefail
+
+# The image of azure-pipelines-orchestrator to test
+IMAGE_TO_TEST=$1
+# The Azue DevOps Org URL
+ORG_URL=$2
+# The Azure DevOps Personal Access Token
+ORG_PAT=$3
+
+function log() {
+    TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")
+    LEVEL=${2:-INFO}
+    echo "[${LEVEL}][${TIMESTAMP}] ${1}"
+}
+
+function cleanupPipeline() {
+  log "Deleting Pipeline ${1}"
+  az pipelines delete --id "${1}" --org "${ORG_URL}" -p "${ADO_PROJECT}" --yes
+}
+
+log "-- Starting integration test ---"
+
+# Create the namespace if it doesn't exist
+kubectl create namespace ${NAMESPACE} 2>/dev/null
+
+log "Granting default service account edit permissions"
+
+# Grant the default service account the ability to
+# do most things in the test namespace
+kubectl apply -n ${NAMESPACE} -f - << EOF
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-edit
+subjects:
+- kind: ServiceAccount
+  name: default # "name" is case sensitive
+  namespace: ${NAMESPACE}
+roleRef:
+  kind: ClusterRole #this must be Role or ClusterRole
+  name: edit
+  apiGroup: rbac.authorization.k8s.io
+EOF
+
+log "Wating ${TEST_TIMEOUT} for orchestrator with image ${IMAGE_TO_TEST}"
+
+# Deploy the agent-orchestrator onto kubernetes
+kubectl apply -n ${NAMESPACE} -f - << EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ado-orchestrator-deployment
+  labels:
+    app: ado-orchestrator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ado-orchestrator
+  template:
+    metadata:
+      labels:
+        app: ado-orchestrator
+    spec:
+      containers:
+      - name: ado-orchestrator
+        image: ${IMAGE_TO_TEST}
+        env:
+        - name: ORG_URL
+          value: "${ORG_URL}"
+        - name: ORG_PAT
+          value: "${ORG_PAT}"
+        - name: AGENT_POOLS
+          value: "${AGENT_POOLS}"
+        - name: JOB_IMAGE
+          value: "${JOB_IMAGE}"
+        - name: JOB_NAMESPACE
+          value: "${NAMESPACE}"
+        - name: MINIMUM_AGENT_COUNT
+          value: "0"
+EOF
+
+# Wait for the deployment to become ready
+kubectl wait deployment/ado-orchestrator-deployment -n ${NAMESPACE} --for condition=Available --timeout=${TEST_TIMEOUT}
+
+log "Orchestrator successfully deployed"
+
+log "Logging into Azure"
+
+echo  ${ORG_PAT} | az devops login --organization ${ORG_URL}
+
+log "Asserting there are no jobs"
+
+JOB_COUNT=$(kubectl get job -n ${NAMESPACE} --no-headers | wc -l)
+
+if [ "${JOB_COUNT}" -gt 0 ]; then
+    log "Assertion failed: expected 0 jobs, got ${JOB_COUNT}" "ERROR"
+    kubectl describe job -n ${NAMESPACE}
+    exit 1
+fi
+
+RANDOM_PIPELINE_NAME="${PIPELINE_NAME}-${RANDOM}"
+
+log "Creating Pipeline Test pipeline [${RANDOM_PIPELINE_NAME}]"
+
+az pipelines create --name "${RANDOM_PIPELINE_NAME}" \
+  --description 'Pipeline for integration tests' \
+  --repository "${ORG_URL}/${ADO_PROJECT}/_git/${PIPELINE_REPO}" \
+  --project "${ADO_PROJECT}" \
+  --branch main \
+  --yml-path azure-pipelines.yml
+
+# Fetch the ID of the pipeline so we can remove it later
+PIPELINE_ID=$(az pipelines list --org "${ORG_URL}" -p "${ADO_PROJECT}" --name "${RANDOM_PIPELINE_NAME}" -o table | awk '{print $1}' | tail -1)
+
+# try up to 10 times for the job to be created
+for i in {1..10}
+do
+  log "Checking if job exists..."
+   JOB_COUNT=$(kubectl get job -n ${NAMESPACE} --no-headers | wc -l)
+   # Break if we find the job
+   if [ "${JOB_COUNT}" -eq 1 ]; then
+    break
+   fi
+   log "Job Count: ${JOB_COUNT}"
+   sleep 5s
+done
+
+# Check one more time in case above loop ran 10 times without starting job
+JOB_COUNT=$(kubectl get job -n ${NAMESPACE} --no-headers | wc -l)
+
+if [ "${JOB_COUNT}" -ne 1 ]; then
+    log "Assertion failed: expected 1 jobs, got ${JOB_COUNT}" "ERROR"
+    kubectl describe deployment/ado-orchestrator-deployment -n ${NAMESPACE}
+    kubectl logs deployment/ado-orchestrator-deployment -n ${NAMESPACE}
+    cleanupPipeline "${PIPELINE_ID}"
+    exit 1
+fi
+
+JOB_NAME=$(kubectl get job -n ${NAMESPACE} -o=jsonpath="{.items[0].metadata.labels.job-name}")
+
+log "Waiting ${TEST_TIMEOUT} for Job/${JOB_NAME} to finish"
+
+# Wait for job to finish
+kubectl wait job/${JOB_NAME} -n ${NAMESPACE} --for condition=Complete --timeout=${TEST_TIMEOUT}
+
+# Output some information about the job, including the logs
+kubectl describe job/${JOB_NAME} -n ${NAMESPACE}
+kubectl logs job/${JOB_NAME}  -n ${NAMESPACE}
+
+cleanupPipeline "${PIPELINE_ID}"
+
+log "-- Result: SUCCESS ---" 


### PR DESCRIPTION
The integration tests are designed to test the `azure-pipelines-orchestrator` on an actual Kubernetes cluster against a live Azure DevOps repo. During the test, a [kind cluster](https://kind.sigs.k8s.io/) is provisioned using the `kind-config.yaml` file that has both a local docker registry, and an `nginx` Ingress. The orchestrator is deployed, and a temporary pipeline is created for the life of tht test. Then, a pipeline job is queued to run and the script will monitor to see if the orchestrator correctly spawns a corresponding `Job` object in K8s.